### PR TITLE
fix nil error (.LoadBalancer might be null for some traefik services)

### DIFF
--- a/traefik/traefik.go
+++ b/traefik/traefik.go
@@ -194,7 +194,9 @@ func (a *Aggregator) getNodesInfoV2() (map[string]*NodeInfo, error) {
 
 	for _, b := range serviceInfo {
 		backName := b.Name[:strings.LastIndex(b.Name, "@")]
-		nodesInfo[backName] = &NodeInfo{URL: b.LoadBalancer.Servers[0].URL}
+		if b.LoadBalancer != nil {
+			nodesInfo[backName] = &NodeInfo{URL: b.LoadBalancer.Servers[0].URL}
+		}
 	}
 
 	return nodesInfo, nil


### PR DESCRIPTION
For some traefik services the LoadBalancer property is nil, which leads to a nil pointer error here if not checked.
