### PR TITLE
Release Index service 5.10.1

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 		K8sMode               bool   `env:"K8S_MODE"          envDefault:"false"`
 		TraefikV2Mode         bool   `env:"TRAEFIK_V2_MODE"   envDefault:"false"`
 		TraefikContainerBased bool   `env:"TRAEFIK_CONTAINER" envDefault:"true"`
-		UsePath               bool   `env:"USE_PATH"          envDefault:"false"`
+		usePathPrefix         bool   `env:"USE_PATH_PREFIX"   envDefault:"false"`
 		TraefikLbURL          string `env:"LB_URL"            envDefault:"http://localhost:8081"`
 		LogLevel              string `env:"LOG_LEVEL"         envDefault:"info"`
 		Path                  string `env:"RESOURCE_PATH"     envDefault:""`
@@ -57,7 +57,13 @@ func main() {
 			log.Fatalf("Incorrect K8S config %s", err.Error())
 		}
 	} else {
-		aggreg = traefik.NewAggregator(rpCfg.TraefikLbURL, rpCfg.TraefikV2Mode, rpCfg.TraefikContainerBased, rpCfg.UsePath, httpClientTimeout)
+		aggreg = traefik.NewAggregator(
+			rpCfg.TraefikLbURL,
+			rpCfg.TraefikV2Mode,
+			rpCfg.TraefikContainerBased,
+			rpCfg.usePathPrefix,
+			httpClientTimeout,
+		)
 	}
 
 	srv.WithRouter(func(router *chi.Mux) {

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 		K8sMode               bool   `env:"K8S_MODE"          envDefault:"false"`
 		TraefikV2Mode         bool   `env:"TRAEFIK_V2_MODE"   envDefault:"false"`
 		TraefikContainerBased bool   `env:"TRAEFIK_CONTAINER" envDefault:"true"`
-		usePathPrefix         bool   `env:"USE_PATH_PREFIX"   envDefault:"false"`
+		UsePathPrefix         bool   `env:"USE_PATH_PREFIX"   envDefault:"false"`
 		TraefikLbURL          string `env:"LB_URL"            envDefault:"http://localhost:8081"`
 		LogLevel              string `env:"LOG_LEVEL"         envDefault:"info"`
 		Path                  string `env:"RESOURCE_PATH"     envDefault:""`
@@ -61,7 +61,7 @@ func main() {
 			rpCfg.TraefikLbURL,
 			rpCfg.TraefikV2Mode,
 			rpCfg.TraefikContainerBased,
-			rpCfg.usePathPrefix,
+			rpCfg.UsePathPrefix,
 			httpClientTimeout,
 		)
 	}

--- a/traefik/traefik.go
+++ b/traefik/traefik.go
@@ -58,7 +58,7 @@ type Aggregator struct {
 	traefikURL     string
 	v2             bool
 	containerBased bool
-	usePath        bool
+	usePathPrefix  bool
 }
 
 // NodeInfo embeds node-related information
@@ -87,7 +87,7 @@ func (ni *NodeInfo) GetHealthEndpoint() string {
 }
 
 // NewAggregator creates new traefik aggregator
-func NewAggregator(traefikURL string, traefikV2 bool, containerBased bool, usePath bool, timeout time.Duration) *Aggregator {
+func NewAggregator(traefikURL string, traefikV2 bool, containerBased bool, usePathPrefix bool, timeout time.Duration) *Aggregator {
 	return &Aggregator{
 		r: resty.NewWithClient(&http.Client{
 			Timeout: timeout,
@@ -95,7 +95,7 @@ func NewAggregator(traefikURL string, traefikV2 bool, containerBased bool, usePa
 		traefikURL:     traefikURL,
 		v2:             traefikV2,
 		containerBased: containerBased,
-		usePath:        usePath,
+		usePathPrefix:  usePathPrefix,
 	}
 }
 
@@ -142,7 +142,7 @@ func (a *Aggregator) aggregate(f func(ni *NodeInfo) (interface{}, error)) map[st
 	if a.containerBased {
 		if a.v2 {
 			nodesInfo, err = a.getNodesInfoV2()
-		} else if a.usePath {
+		} else if a.usePathPrefix {
 			nodesInfo, err = a.getNodesInfoWithPath()
 		} else {
 			nodesInfo, err = a.getNodesInfo()


### PR DESCRIPTION
This release adds a feature that allows you to use a prefix in the base path for other backend services without trimming it.