### PR TITLE
Feature/epmrpp 98957

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,3 +11,4 @@ jobs:
       release_version: ${{ github.event.release.tag_name }}
       repository_url: 'https://repo1.maven.org/maven2/com/epam/reportportal'
       branch: feature/EPMRPP-98957
+      service_name: service/index

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,4 @@ jobs:
     with:
       release_version: ${{ github.event.release.tag_name }}
       repository_url: 'https://repo1.maven.org/maven2/com/epam/reportportal'
-      go_command: go build
-      output_dir: ./build/
-      branch: feature/EPMRPP-98957 
+      branch: feature/EPMRPP-98957

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   publish-artifacts:
-    uses: reportportal/.github/.github/workflows/go-build-release.yaml@feature/EPMRPP-98957
+    uses: reportportal/.github/.github/workflows/go-build-release.yaml@main
     with:
       release_version: ${{ github.event.release.tag_name }}
       repository_url: 'https://repo1.maven.org/maven2/com/epam/reportportal'
-      branch: feature/EPMRPP-98957
+      branch: master
       service_name: service/index

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,6 @@ jobs:
     uses: reportportal/.github/.github/workflows/go-build-release.yaml@main
     with:
       release_version: ${{ github.event.release.tag_name }}
-      repository_url: 'https://repo1.maven.org/maven2/com/epam/reportportal'
+      go_version: 1.22.6
       branch: master
       service_name: service/index

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@ on:
 jobs:
   publish-artifacts:
     uses: reportportal/.github/.github/workflows/go-build-release.yaml@feature/EPMRPP-98957
-
     with:
       release_version: ${{ github.event.release.tag_name }}
-      repository_url: 'https://maven.pkg.github.com/'
-      gradle_command: ./gradlew build
-      branch: feature/EPMRPP-98957
+      repository_url: 'https://repo1.maven.org/maven2/com/epam/reportportal'
+      go_command: go build
+      output_dir: ./build/
+      branch: feature/EPMRPP-98957 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release Workflow
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-artifacts:
+    uses: reportportal/.github/.github/workflows/go-build-release.yaml@feature/EPMRPP-98957
+
+    with:
+      release_version: ${{ github.event.release.tag_name }}
+      repository_url: 'https://maven.pkg.github.com/'
+      gradle_command: ./gradlew build
+      branch: feature/EPMRPP-98957

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,5 @@ jobs:
   publish-artifacts:
     uses: reportportal/.github/.github/workflows/go-build-release.yaml@main
     with:
-      release_version: ${{ github.event.release.tag_name }}
       go_version: 1.22.6
-      branch: master
       service_name: service/index

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v5.test.release
+v5.test.go.release

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v5.test.go.release
+5.13.0

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-5.13.0
+v5.test.release


### PR DESCRIPTION
This PR updates the release workflow for the service/index (Go) to align with the latest project requirements. Key updates include:

**Dynamic service_name Support:**

The workflow now accepts a dynamic service_name input, enabling compatibility with services using the service-* prefix.
In this case, it specifically targets service/index, ensuring consistent artifact naming and publishing.

**Branch Validation and Checkout:**

The workflow ensures that all processes are executed exclusively on the master branch.
Removed redundant branch validation as the checkout step is explicitly configured to always use master.
Artifact Generation and Upload Improvements:

Adjustments have been made to ensure artifacts are named using the correct release tag (release_version).
Enhanced error handling to prevent conflicts when an artifact with the same name already exists in the release.
Robust Tag and Release Management:

Ensures consistency between the release tag and the generated artifacts.
Artifacts are only uploaded when they match the active release tag.

**How to Use**
Create a release with a tag associated with the service/index.
Verify that the workflow builds the binary correctly and uploads it as an artifact to the release.
Confirm that the uploaded artifact follows the expected naming convention: service-index-<release_version>.release.
**Important Notes**
This PR introduces a more flexible and scalable process to support additional services in the future.
It ensures that the service/index is fully integrated with the dynamic release workflow.