### PR TITLE
EPMRPP-110955 | migrate dockerhub-release workflow to reusable OIDC-based pipeline

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -29,8 +29,8 @@ jobs:
     uses: reportportal/.github/.github/workflows/build-docker-image.yaml@main
     with:
       aws-region: ${{ vars.AWS_REGION }}
+      aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
       image-tag: 'develop-${{ github.run_number }}'
       additional-tag: 'develop-latest'
       version: 'develop-${{ github.run_number }}'
       date: ${{ needs.variables-setup.outputs.date }}
-    secrets: inherit

--- a/.github/workflows/build-feature-image.yaml
+++ b/.github/workflows/build-feature-image.yaml
@@ -34,4 +34,5 @@ jobs:
       version: ${{ needs.variables-setup.outputs.tag }}
       branch: ${{ github.head_ref }}
       date: ${{ needs.variables-setup.outputs.date }}
-    secrets: inherit
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/build-feature-image.yaml
+++ b/.github/workflows/build-feature-image.yaml
@@ -30,9 +30,9 @@ jobs:
     uses: reportportal/.github/.github/workflows/build-docker-image.yaml@main
     with:
       aws-region: ${{ vars.AWS_REGION }}
+      aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
       image-tag: ${{ needs.variables-setup.outputs.tag }}
       version: ${{ needs.variables-setup.outputs.tag }}
       branch: ${{ github.head_ref }}
       date: ${{ needs.variables-setup.outputs.date }}
-    secrets:
-      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+

--- a/.github/workflows/build-rc-image.yaml
+++ b/.github/workflows/build-rc-image.yaml
@@ -34,11 +34,10 @@ jobs:
     uses: reportportal/.github/.github/workflows/build-docker-image.yaml@main
     with:
       aws-region: ${{ vars.AWS_REGION }}
+      aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
       image-tag: ${{ needs.variables-setup.outputs.tag }}
       additional-tag: 'latest'
       build-platforms: ${{ needs.variables-setup.outputs.platforms }}
       version: ${{ needs.variables-setup.outputs.version }}
       date: ${{ needs.variables-setup.outputs.date }}
       scan-image: true
-    secrets:
-      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/build-rc-image.yaml
+++ b/.github/workflows/build-rc-image.yaml
@@ -40,4 +40,5 @@ jobs:
       version: ${{ needs.variables-setup.outputs.version }}
       date: ${{ needs.variables-setup.outputs.date }}
       scan-image: true
-    secrets: inherit
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/dockerhub-release.yaml
+++ b/.github/workflows/dockerhub-release.yaml
@@ -9,7 +9,7 @@ jobs:
     if: >
       github.event.review.state == 'approved'
     # TODO: Pin reusable workflow to a version tag once v1 is released
-    uses: reportportal/.github/.github/workflows/dockerhub-release.yaml@main
+    uses: reportportal/.github/.github/workflows/dockerhub-release.yaml@0cfc683f89cee91ccc24f05c728b00f23027e7f2
     secrets:
       REGESTRY_USERNAME: ${{ secrets.REGESTRY_USERNAME }}
       REGESTRY_PASSWORD: ${{ secrets.REGESTRY_PASSWORD }}

--- a/.github/workflows/dockerhub-release.yaml
+++ b/.github/workflows/dockerhub-release.yaml
@@ -11,7 +11,6 @@ jobs:
     # TODO: Pin reusable workflow to a version tag once v1 is released
     uses: reportportal/.github/.github/workflows/dockerhub-release.yaml@main
     secrets:
-      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       REGESTRY_USERNAME: ${{ secrets.REGESTRY_USERNAME }}
       REGESTRY_PASSWORD: ${{ secrets.REGESTRY_PASSWORD }}
     with:

--- a/.github/workflows/dockerhub-release.yaml
+++ b/.github/workflows/dockerhub-release.yaml
@@ -10,7 +10,10 @@ jobs:
       github.event.review.state == 'approved'
     # TODO: Pin reusable workflow to a version tag once v1 is released
     uses: reportportal/.github/.github/workflows/dockerhub-release.yaml@main
-    secrets: inherit
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      REGESTRY_USERNAME: ${{ secrets.REGESTRY_USERNAME }}
+      REGESTRY_PASSWORD: ${{ secrets.REGESTRY_PASSWORD }}
     with:
       aws-region: ${{ vars.AWS_REGION }}
       aws-role-arn: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/dockerhub-release.yaml
+++ b/.github/workflows/dockerhub-release.yaml
@@ -4,68 +4,18 @@ on:
   pull_request_review:
     types: [submitted]
 
-env:
-  AWS_REGION: ${{ vars.AWS_REGION }}               # set this to your preferred AWS region, e.g. us-west-1
-  ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}       # set this to your Amazon ECR repository name
-  TARGET_REGISTRY: ${{ vars.TARGET_REGISTRY }}     # set to target regestry (DockerHub, GitHub & etc)
-  TARGET_REPOSITORY: ${{ vars.TARGET_REPOSITORY }} # set to target repository
-  PLATFORMS: ${{ vars.BUILD_PLATFORMS }}           # set target build platforms. By default linux/amd64
-  RELEASE_MODE: ${{ vars.RELEASE_MODE }}
-
 jobs:
-  retag-image:
-    name: Retag and push image 
-    runs-on: ubuntu-latest
-    environment: rc
-    if: github.event.review.state == 'approved' && (github.event.pull_request.base.ref == 'master' || github.event.pull_request.base.ref == 'main')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          # role-to-assume: arn:aws:iam::123456789012:role/my-github-actions-role
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          mask-password: 'true'
-      
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.REGESTRY_USERNAME }}
-          password: ${{ secrets.REGESTRY_PASSWORD }}
-      
-      - name: Create variables
-        id: vars
-        run: |
-          echo "tag=$(echo '${{ github.event.pull_request.title }}' | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')" >> $GITHUB_OUTPUT
-      
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Retag and Push Docker Image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ steps.vars.outputs.tag }}
-        run: |
-          docker buildx imagetools create $ECR_REGISTRY/$ECR_REPOSITORY:latest --tag $TARGET_REGISTRY/$TARGET_REPOSITORY:$IMAGE_TAG --tag $TARGET_REGISTRY/$TARGET_REPOSITORY:latest
-      
-      - name: Summarize
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ steps.vars.outputs.tag }}
-        run: |
-          echo "## General information about the build:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- :whale: Docker image: $TARGET_REGISTRY/$TARGET_REPOSITORY:$IMAGE_TAG" >> $GITHUB_STEP_SUMMARY
-          echo "- :octocat: The commit SHA from which the build was performed: [$GITHUB_SHA](https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA)" >> $GITHUB_STEP_SUMMARY
+  release:
+    if: >
+      github.event.review.state == 'approved'
+    # TODO: Pin reusable workflow to a version tag once v1 is released
+    uses: reportportal/.github/.github/workflows/dockerhub-release.yaml@main
+    secrets: inherit
+    with:
+      aws-region: ${{ vars.AWS_REGION }}
+      aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
+      ecr-repository: service-index
+      target-registry: docker.io
+      target-repository: reportportal/service-index
+      platforms: linux/amd64
+      release-mode: rc


### PR DESCRIPTION
This PR migrates the dockerhub-release logic to the shared reusable
GitHub Actions workflow located in reportportal/.github.

What changed:
- Replaced repository-specific dockerhub-release workflow with a reusable one
- Centralized release/retag logic to reduce duplication and maintenance
- Switched AWS authentication to OIDC-based role assumption (no static credentials)

Behavior:
- Workflow remains approval-gated via pull_request_review
- Execution is restricted to main/master branches
- Release version is derived from the PR title (semver)

Security:
- No AWS access keys or secrets are stored in this repository
- AWS access is granted via short-lived OIDC credentials and IAM role trust

Impact:
- No functional change to release behavior
- No production deployment changes
- Improves consistency and security across services

Safe to approve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the Docker image release process to use a shared reusable workflow, improving consistency and maintainability.
  * Reduced secret propagation to downstream build jobs so only required credentials are forwarded, tightening pipeline security and minimizing exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->